### PR TITLE
feature: healthcheck annotations for HTTPScaledObject

### DIFF
--- a/interceptor/middleware/counting.go
+++ b/interceptor/middleware/counting.go
@@ -30,7 +30,11 @@ func (cm *Counting) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = util.RequestWithLoggerWithName(r, "CountingMiddleware")
 	ctx := r.Context()
 
-	defer cm.countAsync(ctx)()
+	isHealthCheck := util.HealthCheckFromContext(ctx)
+	if !isHealthCheck {
+		// exclude health checks from counting
+		defer cm.countAsync(ctx)()
+	}
 
 	cm.upstreamHandler.ServeHTTP(w, r)
 }

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -15,6 +15,7 @@ const (
 	ckLogger contextKey = iota
 	ckHTTPSO
 	ckStream
+	ckHealthCheck
 )
 
 func ContextWithLogger(ctx context.Context, logger logr.Logger) context.Context {
@@ -30,8 +31,17 @@ func ContextWithHTTPSO(ctx context.Context, httpso *httpv1alpha1.HTTPScaledObjec
 	return context.WithValue(ctx, ckHTTPSO, httpso)
 }
 
+func ContextWithHealthCheck(ctx context.Context, isHealthCheck bool) context.Context {
+	return context.WithValue(ctx, ckHealthCheck, isHealthCheck)
+}
+
 func HTTPSOFromContext(ctx context.Context) *httpv1alpha1.HTTPScaledObject {
 	cv, _ := ctx.Value(ckHTTPSO).(*httpv1alpha1.HTTPScaledObject)
+	return cv
+}
+
+func HealthCheckFromContext(ctx context.Context) bool {
+	cv, _ := ctx.Value(ckHealthCheck).(bool)
 	return cv
 }
 


### PR DESCRIPTION
It's common practice to configure healthchecks for applications to exclude unhealthy replicas from loadbalancing requests. But this defeats the purpose of scaling to 0 based on HTTP traffic because healthchecks generate that HTTP traffic which would scale the application up.

This PR introduces two annotations on `HTTPScaledObject` that instructs `interceptor` to respond to healthchecks on behalf of the scaled application instead of proxying this check to the application and triggering cold-start.

* `http.kedify.io/healthcheck-path: [path]`
* `http.kedify.io/healthcheck-response: [static | passthrough]`

For `static` the interceptor will respond, for `passthrough` the interceptor will respond only if the application is scaled to 0, otherwise, it proxies the request on the same path to the application.

The requests for preconfigured healthcheck path are excluded from the counter stats.

Example configuration instructing interceptor to respond to requests for `www.app-1.com/healthz` when scaled to 0:
```yaml
kind: HTTPScaledObject
apiVersion: http.keda.sh/v1alpha1
metadata:
  name: app-1
  annotations:
    http.kedify.io/healthcheck-path: /healthz
    http.kedify.io/healthcheck-response: passthrough
spec:
  hosts:
    - www.app-1.com
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: app-1
    service: app-1
    port: 8080
  replicas:
    min: 0
    max: 10
  scalingMetric:
    requestRate:
      targetValue: 1
  scaledownPeriod: 5
```