### PR TITLE
envoy metrics sink

### DIFF
--- a/config/interceptor/kedify_proxy_sink.service.yaml
+++ b/config/interceptor/kedify_proxy_sink.service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: interceptor-kedify-proxy-metric-sink
+spec:
+  type: ClusterIP
+  ports:
+  - name: proxy
+    port: 9901
+    protocol: TCP
+    targetPort: 9901

--- a/config/interceptor/kustomization.yaml
+++ b/config/interceptor/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - role_binding.yaml
 - admin.service.yaml
 - proxy.service.yaml
+- envoy_sink.service.yaml
 - metrics.service.yaml
 - service_account.yaml
 - scaledobject.yaml

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kedacore/http-add-on
 go 1.22.2
 
 require (
+	github.com/envoyproxy/go-control-plane v0.12.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
@@ -25,6 +26,11 @@ require (
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.17.5
 	sigs.k8s.io/kustomize/kustomize/v5 v5.4.2
+)
+
+require (
+	github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50 h1:DBmgJDC9dTfkVyGgipamEh2BpGYxScCH1TOF1LL1cXc=
+github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50/go.mod h1:5e1+Vvlzido69INQaVO6d87Qn543Xr6nooe9Kz7oBFM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -15,6 +17,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/envoyproxy/go-control-plane v0.12.0 h1:4X+VP1GHd1Mhj6IB5mMeGbLCleqxjletLK6K0rbxyZI=
+github.com/envoyproxy/go-control-plane v0.12.0/go.mod h1:ZBTaoJ23lqITozF0M6G4/IragXCQKCnYbmlmtHvwRG0=
+github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU4zdyUgIUNhlgg0A=
+github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -21,6 +21,8 @@ type Serving struct {
 	// This is the server that the external scaler will issue metrics
 	// requests to
 	AdminPort int `envconfig:"KEDA_HTTP_ADMIN_PORT" required:"true"`
+	// EnvoyStatsMetricSinkPort is the port that the external envoy proxies can send metrics to.
+	EnvoyStatsMetricSinkPort int `envconfig:"KEDA_HTTP_ENVOY_STATS_METRIC_SINK_PORT" default:"9901"`
 	// ConfigMapCacheRsyncPeriod is the time interval
 	// for the configmap informer to rsync the local cache.
 	ConfigMapCacheRsyncPeriod time.Duration `envconfig:"KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD" default:"60m"`

--- a/interceptor/envoysink/metrics_server.go
+++ b/interceptor/envoysink/metrics_server.go
@@ -1,0 +1,257 @@
+/*
+Package envoysink provides a gRPC server for the envoy metrics service sink.
+
+External envoy proxies used to offload the traffic from the interceptor can push their metrics
+to this server. The interceptor admin endpoint aggregates internal and external queues to a single
+metric per HTTPScaledObject which is used by KEDA for scaling.
+*/
+package envoysink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	envoycpv3 "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v3"
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
+	"github.com/kedacore/http-add-on/operator/generated/informers/externalversions"
+	informershttpv1alpha1 "github.com/kedacore/http-add-on/operator/generated/informers/externalversions/http/v1alpha1"
+	"github.com/kedacore/http-add-on/pkg/queue"
+)
+
+const (
+	// envoyClusterNameAnnotation is the annotation key for the envoy cluster name.
+	envoyClusterNameAnnotation = "http.kedify.io/envoy-cluster-name"
+
+	// envoy metrics representing RPS and pending requests.
+	envoyMetricRPS         = "cluster.upstream_rq_total"
+	envoyMetricConcurrency = "cluster.upstream_rq_active"
+
+	// EnvoyMetricLabelClusterName is the label name for the cluster name.
+	EnvoyMetricLabelClusterName = "envoy.cluster_name"
+)
+
+type counter interface {
+	queue.Counter
+
+	// SetRPS sets the RPS for the given host.
+	SetRPS(host string, rps int) error
+	// SetConcurrency sets the concurrency for the given host.
+	SetConcurrency(host string, concurrency int) error
+}
+
+// metricsServiceServer is a server for the metrics service.
+type metricsServiceServer struct {
+	envoycpv3.UnimplementedMetricsServiceServer
+
+	log logr.Logger
+
+	// concurrentMap is a map of gRPC stream id to map of host to value, access is protected by lock.
+	concurrentMap     map[string]map[string]float64
+	concurrentMapLock sync.RWMutex
+
+	// counter is the counter to store the metrics and calculate the rate.
+	counter counter
+
+	// envoyClusterToHSOMap is a map of envoy cluster_name to the HTTPScaledObject.
+	envoyClusterToHSOMap     map[string]*v1alpha1.HTTPScaledObject
+	envoyClusterToHSOMapLock sync.RWMutex
+}
+
+// NewMetricsServiceServer creates a new metrics service server.
+func NewMetricsServiceServer(lggr logr.Logger, counter counter, sharedInformerFactory externalversions.SharedInformerFactory, namespace string) (*metricsServiceServer, error) {
+	s := &metricsServiceServer{
+		log:                      lggr,
+		concurrentMap:            map[string]map[string]float64{},
+		concurrentMapLock:        sync.RWMutex{},
+		counter:                  counter,
+		envoyClusterToHSOMap:     map[string]*v1alpha1.HTTPScaledObject{},
+		envoyClusterToHSOMapLock: sync.RWMutex{},
+	}
+	err := s.setupHTTPScaledObjectInformer(sharedInformerFactory, namespace)
+	return s, err
+}
+
+// StreamMetrics is the implementation of the StreamMetrics RPC method.
+func (s *metricsServiceServer) StreamMetrics(stream envoycpv3.MetricsService_StreamMetricsServer) error {
+	id := uuid.New().String()
+	s.concurrentMapLock.Lock()
+	s.concurrentMap[id] = map[string]float64{}
+	s.concurrentMapLock.Unlock()
+	for {
+		m, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		s.processMetrics(id, m)
+	}
+	s.concurrentMapLock.Lock()
+	delete(s.concurrentMap, id)
+	s.concurrentMapLock.Unlock()
+	return nil
+}
+
+func (s *metricsServiceServer) setupHTTPScaledObjectInformer(sharedInformerFactory externalversions.SharedInformerFactory, namespace string) error {
+	httpScaledObjects := informershttpv1alpha1.New(sharedInformerFactory, namespace, nil).HTTPScaledObjects()
+	informer, ok := httpScaledObjects.Informer().(cache.SharedIndexInformer)
+	if !ok {
+		return errors.New("informer is not cache.sharedIndexInformer")
+	}
+	_, err := informer.AddEventHandler(s)
+	return err
+}
+
+// Run starts the metrics service server.
+func (s *metricsServiceServer) Run(ctx context.Context, port int) error {
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return err
+	}
+	grpcServer := grpc.NewServer()
+	envoycpv3.RegisterMetricsServiceServer(grpcServer, s)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			s.log.Error(err, "failed to serve")
+		}
+	}()
+	return nil
+}
+
+// processMetrics processes the pushed metrics from envoys
+func (s *metricsServiceServer) processMetrics(id string, m *envoycpv3.StreamMetricsMessage) {
+	for _, m := range m.EnvoyMetrics {
+		if m.GetName() == envoyMetricRPS || m.GetName() == envoyMetricConcurrency {
+			for _, metricData := range m.Metric {
+				for _, label := range metricData.Label {
+					if label.GetName() == EnvoyMetricLabelClusterName {
+						host := s.convertEnvoyClusterNameToHostKey(label.GetValue())
+						if host == "" {
+							break
+						}
+						switch m.GetName() {
+						case envoyMetricRPS:
+							if metricData.GetCounter().GetValue() == 0 {
+								// in order to allow fast scaling with RPS, leading 0 buckets in window should not be inserted
+								// the RPS calculation works well with empty trailing and middle buckets
+								continue
+							}
+							s.counter.SetRPS(host, int(metricData.GetCounter().GetValue()))
+						case envoyMetricConcurrency:
+							s.concurrentMapLock.Lock()
+							s.concurrentMap[id][host] = metricData.GetGauge().GetValue()
+							s.concurrentMapLock.Unlock()
+							val := 0
+							s.concurrentMapLock.RLock()
+							for _, v := range s.concurrentMap {
+								val += int(v[host])
+							}
+							s.concurrentMapLock.RUnlock()
+							s.counter.SetConcurrency(host, val)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// OnAdd handles the creation of the HTTPScaledObject.
+func (s *metricsServiceServer) OnAdd(obj any, _ bool) {
+	hso, ok := obj.(*v1alpha1.HTTPScaledObject)
+	if !ok {
+		s.log.Info("not a HTTPScaledObject", "obj", obj, "type", fmt.Sprintf("%T", obj))
+		return
+	}
+
+	clusterName := hso.Annotations[envoyClusterNameAnnotation]
+	if clusterName == "" {
+		s.log.V(4).Info("cluster name not found", "hso", hso)
+		return
+	}
+	s.addClusterNameToMetrics(clusterName, hso)
+}
+
+// OnUpdate handles the update of the HTTPScaledObject.
+func (s *metricsServiceServer) OnUpdate(o, n any) {
+	hsoOld, ok := o.(*v1alpha1.HTTPScaledObject)
+	if !ok {
+		s.log.Info("not a HTTPScaledObject", "objOld", o, "type", fmt.Sprintf("%T", o))
+		return
+	}
+	hsoNew, ok := n.(*v1alpha1.HTTPScaledObject)
+	if !ok {
+		s.log.Info("not a HTTPScaledObject", "objNew", n, "type", fmt.Sprintf("%T", n))
+		return
+	}
+	if hsoNew.Annotations[envoyClusterNameAnnotation] == hsoOld.Annotations[envoyClusterNameAnnotation] {
+		s.log.V(4).Info("cluster name did not change", "hso", hsoNew)
+		return
+	}
+
+	oldClusterName := hsoOld.Annotations[envoyClusterNameAnnotation]
+	if oldClusterName != "" {
+		s.deleteClusterNameFromMetrics(oldClusterName, hsoOld)
+	}
+	newClusterName := hsoNew.Annotations[envoyClusterNameAnnotation]
+	if newClusterName != "" {
+		s.addClusterNameToMetrics(newClusterName, hsoNew)
+	}
+}
+
+// OnDelete handles the deletion of the HTTPScaledObject.
+func (s *metricsServiceServer) OnDelete(obj any) {
+	hso, ok := obj.(*v1alpha1.HTTPScaledObject)
+	if !ok {
+		s.log.Info("not a HTTPScaledObject", "obj", obj, "type", fmt.Sprintf("%T", obj))
+		return
+	}
+	clusterName := hso.Annotations[envoyClusterNameAnnotation]
+	if clusterName == "" {
+		s.log.V(4).Info("cluster name not found", "hso", hso)
+		return
+	}
+	s.deleteClusterNameFromMetrics(clusterName, hso)
+}
+
+// addCluserNameToMetrics adds the cluster name to the metrics.
+func (s *metricsServiceServer) addClusterNameToMetrics(clusterName string, hso *v1alpha1.HTTPScaledObject) {
+	window := 1 * time.Minute
+	granularity := 1 * time.Second
+	if hso.Spec.ScalingMetric != nil && hso.Spec.ScalingMetric.Rate != nil {
+		window = hso.Spec.ScalingMetric.Rate.Window.Duration
+	}
+	host := hso.Namespace + "/" + hso.Name
+	s.counter.EnsureKey(host, window, granularity)
+	s.envoyClusterToHSOMapLock.Lock()
+	s.envoyClusterToHSOMap[clusterName] = hso
+	s.envoyClusterToHSOMapLock.Unlock()
+}
+
+// deleteCluserNameFromMetrics deletes the cluster name from the metrics.
+func (s *metricsServiceServer) deleteClusterNameFromMetrics(clusterName string, hso *v1alpha1.HTTPScaledObject) {
+	s.envoyClusterToHSOMapLock.Lock()
+	delete(s.envoyClusterToHSOMap, clusterName)
+	s.envoyClusterToHSOMapLock.Unlock()
+	host := hso.Namespace + "/" + hso.Name
+	s.counter.RemoveKey(host)
+}
+
+// convertEnvoyClusterNameToHostKey converts the envoy cluster name to the host key.
+func (s *metricsServiceServer) convertEnvoyClusterNameToHostKey(clusterName string) string {
+	s.envoyClusterToHSOMapLock.RLock()
+	defer s.envoyClusterToHSOMapLock.RUnlock()
+	hso, ok := s.envoyClusterToHSOMap[clusterName]
+	if !ok {
+		s.log.V(1).Info("cluster name not found for conversion", "clusterName", clusterName)
+		return ""
+	}
+	return hso.Namespace + "/" + hso.Name
+}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -63,6 +63,22 @@ func NewMemory() *Memory {
 	}
 }
 
+// SetRPS sets the RPS for the given host.
+func (r *Memory) SetRPS(host string, rps int) error {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	r.rpsMap[host].Record(time.Now(), rps)
+	return nil
+}
+
+// SetConcurrency sets the concurrency for the given host.
+func (r *Memory) SetConcurrency(host string, concurrency int) error {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	r.concurrentMap[host] = concurrency
+	return nil
+}
+
 // Increase changes the size of the queue adding delta
 func (r *Memory) Increase(host string, delta int) error {
 	r.mut.Lock()


### PR DESCRIPTION
This PR introduces an implementation of a metric sink for the envoy. These metrics are applied to the `interceptor` internal counters and consumed by `scaler` -> `keda` -> `hpa` for scaling. It uses [evoy `MetricsSink` extension](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/metrics/v3/metrics_service.proto#extension-envoy-stat-sinks-metrics-service).

Each `HTTPScaledObject` must contain additional annotation to allow interceptor pairing metrics from envoy with interceptor naming conventions
```
http.kedify.io/envoy-cluster-name: [envoy_cluster_name]
```
Where `envoy_cluster_name` is the envoy `cluster_name` as specified in the envoy config.

Config snippet for the third-party envoy deployment:
```yaml
stats_flush_interval: 1s
stats_sinks:
  name: keda_http_add_on
  typed_config:
    "@type": type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
    transport_api_version: V3
    report_counters_as_deltas: true
    emit_tags_as_labels: true
    grpc_service:
      google_grpc:
        target_uri: keda-add-ons-http-interceptor-kedify-proxy-metric-sink.keda.svc.cluster.local:9901
        stat_prefix: kedify_
```