### PR TITLE
Interceptor: envoy xDS control plane

### DIFF
--- a/config/interceptor/kedify_proxy_sink.service.yaml
+++ b/config/interceptor/kedify_proxy_sink.service.yaml
@@ -9,3 +9,7 @@ spec:
     port: 9901
     protocol: TCP
     targetPort: 9901
+  - name: control-plane
+    port: 5678
+    protocol: TCP
+    targetPort: 5678

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 )
 
 require (
+	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 )
@@ -66,12 +67,12 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golang/protobuf v1.5.4
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240528025155-186aa0362fba // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
+github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50 h1:DBmgJDC9dTfkVyGgipamEh2BpGYxScCH1TOF1LL1cXc=

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -23,6 +23,12 @@ type Serving struct {
 	AdminPort int `envconfig:"KEDA_HTTP_ADMIN_PORT" required:"true"`
 	// EnvoyStatsMetricSinkPort is the port that the external envoy proxies can send metrics to.
 	EnvoyStatsMetricSinkPort int `envconfig:"KEDA_HTTP_ENVOY_STATS_METRIC_SINK_PORT" default:"9901"`
+	// EnvoyControlPlaneServiceName is the name of the service for the envoy control plane
+	EnvoyControlPlaneServiceName string `envconfig:"KEDA_HTTP_ENVOY_CONTROL_PLANE_SERVICE_NAME" default:"keda-add-ons-http-interceptor-kedify-proxy-metric-sink"`
+	// EnvoyControlPlanePort is the port that the envoy control plane server should run on.
+	EnvoyControlPlanePort int `envconfig:"KEDA_HTTP_ENVOY_CONTROL_PLANE_PORT" default:"5678"`
+	// ClusterDomain is the domain that the interceptor should for internal DNS
+	ClusterDomain string `envconfig:"KEDA_HTTP_CLUSTER_DOMAIN" default:"cluster.local"`
 	// ConfigMapCacheRsyncPeriod is the time interval
 	// for the configmap informer to rsync the local cache.
 	ConfigMapCacheRsyncPeriod time.Duration `envconfig:"KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD" default:"60m"`

--- a/interceptor/envoycp/resources.go
+++ b/interceptor/envoycp/resources.go
@@ -1,0 +1,369 @@
+package envoycp
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	duration "github.com/golang/protobuf/ptypes/duration"
+	"golang.org/x/exp/constraints"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	httpaddonv1alpha1 "github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
+)
+
+// getResourcesVersion returns the version of the resources that will form the snapshot
+func getResourcesVersion(resources map[resource.Type][]types.Resource) string {
+	var content []byte
+	snapResourceTypes := []resource.Type{resource.ListenerType, resource.ClusterType}
+	for _, rt := range snapResourceTypes {
+		resource := resources[rt]
+		for _, r := range resource {
+			mr, err := cachev3.MarshalResource(r)
+			if err != nil {
+				return ""
+			}
+			content = append(content, mr...)
+		}
+	}
+	return cachev3.HashResource(content)
+}
+
+// snapVersion returns the version of the snapshot
+func snapVersion(snap *cachev3.Snapshot) string {
+	listenerVersion := snap.GetVersion(resource.ListenerType)
+	clustersVersion := snap.GetVersion(resource.ClusterType)
+	return fmt.Sprintf("%s-%s", listenerVersion, clustersVersion)
+}
+
+// getManager returns the slice of routes translated from HTTPScaledObject spec
+// if there is no HTTPScaledObject.Spec.PathPrefixes, create single envoy route with prefix "/"
+func getRoutes(hsoKey string, hso *httpaddonv1alpha1.HTTPScaledObject) []*routev3.Route {
+	routes := make([]*routev3.Route, len(hso.Spec.PathPrefixes))
+	for i, pathPrefix := range hso.Spec.PathPrefixes {
+		routes[i] = &routev3.Route{
+			Match: &routev3.RouteMatch{
+				PathSpecifier: &routev3.RouteMatch_Prefix{
+					Prefix: pathPrefix,
+				},
+			},
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_Cluster{
+						Cluster: hso.Name,
+					},
+				},
+			},
+		}
+	}
+	if len(routes) == 0 {
+		routes = []*routev3.Route{
+			{
+				Match: &routev3.RouteMatch{
+					PathSpecifier: &routev3.RouteMatch_Prefix{
+						Prefix: "/",
+					},
+				},
+				Action: &routev3.Route_Route{
+					Route: &routev3.RouteAction{
+						ClusterSpecifier: &routev3.RouteAction_Cluster{
+							Cluster: hsoKey,
+						},
+						HostRewriteSpecifier: &routev3.RouteAction_AutoHostRewrite{
+							AutoHostRewrite: wrapperspb.Bool(false),
+						},
+					},
+				},
+			},
+		}
+	}
+	sort.Slice(routes, func(i, j int) bool {
+		return routes[i].Match.PathSpecifier.(*routev3.RouteMatch_Prefix).Prefix < routes[j].Match.PathSpecifier.(*routev3.RouteMatch_Prefix).Prefix
+	})
+	return routes
+}
+
+// getManager returns the HTTPConnectionManager from the listener
+func getManager(listener *listenerv3.Listener) (*httpv3.HttpConnectionManager, error) {
+	tc, ok := listener.FilterChains[0].Filters[0].ConfigType.(*listenerv3.Filter_TypedConfig)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast filter config to typed config")
+	}
+	httpConnManager := &httpv3.HttpConnectionManager{}
+	if err := anypb.UnmarshalTo(tc.TypedConfig, httpConnManager, proto.UnmarshalOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal anypb to http connection manager: %w", err)
+	}
+	return httpConnManager, nil
+}
+
+// updateManager performs in-place update of the HTTPConnectionManager with new routes
+func updateManager(hsoKey string, hso *httpaddonv1alpha1.HTTPScaledObject, httpConnManager *httpv3.HttpConnectionManager) error {
+	routes := getRoutes(hsoKey, hso)
+	rc, ok := httpConnManager.GetRouteSpecifier().(*httpv3.HttpConnectionManager_RouteConfig)
+	if !ok {
+		return fmt.Errorf("failed to cast route config to routev3.RouteConfiguration")
+	}
+	if !hso.DeletionTimestamp.IsZero() {
+		for i, vh := range rc.RouteConfig.VirtualHosts {
+			if vh.Name == hsoKey {
+				rc.RouteConfig.VirtualHosts = append(rc.RouteConfig.VirtualHosts[:i], rc.RouteConfig.VirtualHosts[i+1:]...)
+				break
+			}
+		}
+		return nil
+	}
+	routeConfig := rc.RouteConfig
+	for _, vh := range routeConfig.VirtualHosts {
+		if vh.Name == hsoKey {
+			vh.Domains = hso.Spec.Hosts
+			vh.Routes = routes
+			return nil
+		}
+	}
+
+	routeConfig.VirtualHosts = append(routeConfig.VirtualHosts, &routev3.VirtualHost{
+		Name:    hsoKey,
+		Domains: hso.Spec.Hosts,
+		Routes:  routes,
+	})
+	sort.Slice(routeConfig.VirtualHosts, func(i, j int) bool {
+		return routeConfig.VirtualHosts[i].Name < routeConfig.VirtualHosts[j].Name
+	})
+	return nil
+}
+
+// updateListener performs in-place update of the listener with updated HTTPConnectionManager
+func updateListener(hsoKey string, hso *httpaddonv1alpha1.HTTPScaledObject, listener *listenerv3.Listener) error {
+	httpConnManager, err := getManager(listener)
+	if err != nil {
+		return fmt.Errorf("failed to get http connection manager: %w", err)
+	}
+	if err := updateManager(hsoKey, hso, httpConnManager); err != nil {
+		return fmt.Errorf("failed to update http connection manager: %w", err)
+	}
+	httpConnManagerAny, err := anypb.New(httpConnManager)
+	if err != nil {
+		return fmt.Errorf("failed to anypb http connection manager: %w", err)
+	}
+	listener.FilterChains[0].Filters[0].ConfigType = &listenerv3.Filter_TypedConfig{TypedConfig: httpConnManagerAny}
+	return nil
+}
+
+// getListener returns the listener from the resources map, if it doesn't exist, creates a new listener with initial configuration
+func getListener(resources map[resource.Type][]types.Resource) (*listenerv3.Listener, error) {
+	var listener *listenerv3.Listener
+	res, ok := resources[resource.ListenerType]
+	if !ok {
+		httpRouter, err := anypb.New(&routerv3.Router{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to anypb router: %w", err)
+		}
+
+		httpConnManager := &httpv3.HttpConnectionManager{
+			StatPrefix: "kedify-proxy",
+			CodecType:  httpv3.HttpConnectionManager_AUTO,
+			RouteSpecifier: &httpv3.HttpConnectionManager_RouteConfig{
+				RouteConfig: &routev3.RouteConfiguration{
+					Name:         "kedify-proxy",
+					VirtualHosts: []*routev3.VirtualHost{},
+				},
+			},
+			HttpFilters: []*httpv3.HttpFilter{
+				{
+					Name: wellknown.Router,
+					ConfigType: &httpv3.HttpFilter_TypedConfig{
+						TypedConfig: httpRouter,
+					},
+				},
+			},
+		}
+		httpConnManagerAny, err := anypb.New(httpConnManager)
+		if err != nil {
+			return nil, fmt.Errorf("failed to anypb http connection manager: %w", err)
+		}
+
+		listener = &listenerv3.Listener{
+			Name: "kedify-proxy",
+			Address: &corev3.Address{
+				Address: &corev3.Address_SocketAddress{
+					SocketAddress: &corev3.SocketAddress{
+						Address: "0.0.0.0",
+						PortSpecifier: &corev3.SocketAddress_PortValue{
+							PortValue: 8080,
+						},
+					},
+				},
+			},
+			FilterChains: []*listenerv3.FilterChain{
+				{
+					Filters: []*listenerv3.Filter{
+						{
+							Name: wellknown.HTTPConnectionManager,
+							ConfigType: &listenerv3.Filter_TypedConfig{
+								TypedConfig: httpConnManagerAny,
+							},
+						},
+					},
+				},
+			},
+		}
+		resources[resource.ListenerType] = []types.Resource{listener}
+	} else {
+		listener = res[0].(*listenerv3.Listener)
+	}
+	return listener, nil
+}
+
+// getLoadBalancerEndpoint returns the load balancer endpoint for certain address and port
+func getLoadBalancerEndpoint[T constraints.Integer](address string, port T) *endpointv3.LbEndpoint {
+	return &endpointv3.LbEndpoint{
+		HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+			Endpoint: &endpointv3.Endpoint{
+				Address: &corev3.Address{
+					Address: &corev3.Address_SocketAddress{
+						SocketAddress: &corev3.SocketAddress{
+							Address: address,
+							PortSpecifier: &corev3.SocketAddress_PortValue{
+								PortValue: uint32(port),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// getClusters returns the clusters from the resources map, if it doesn't exist, creates a new cluster
+// with initial configuration for the xDS control plane configuration
+func getClusters(resources map[resource.Type][]types.Resource, cp Options) []*clusterv3.Cluster {
+	clusterResources, ok := resources[resource.ClusterType]
+	if !ok {
+		lbEndpoint := getLoadBalancerEndpoint(cp.ControlPlaneHost, cp.ControlPlanePort)
+		xdsCluster := &clusterv3.Cluster{
+			Name: "xds_cluster",
+			ConnectTimeout: &duration.Duration{
+				Seconds: 2,
+			},
+			ClusterDiscoveryType: &clusterv3.Cluster_Type{
+				Type: clusterv3.Cluster_STRICT_DNS,
+			},
+			LbPolicy:                  clusterv3.Cluster_ROUND_ROBIN,
+			Http2ProtocolOptions:      &corev3.Http2ProtocolOptions{},
+			UpstreamConnectionOptions: &clusterv3.UpstreamConnectionOptions{},
+			LoadAssignment: &endpointv3.ClusterLoadAssignment{
+				ClusterName: "xds_cluster",
+				Endpoints: []*endpointv3.LocalityLbEndpoints{
+					{
+						LbEndpoints: []*endpointv3.LbEndpoint{lbEndpoint},
+					},
+				},
+			},
+		}
+		resources[resource.ClusterType] = []types.Resource{xdsCluster}
+		return []*clusterv3.Cluster{xdsCluster}
+	} else {
+		clusters := make([]*clusterv3.Cluster, len(clusterResources))
+		for i, r := range clusterResources {
+			clusters[i] = r.(*clusterv3.Cluster)
+		}
+		return clusters
+	}
+}
+
+// updateClusters updates the clusters for the new HTTPScaledObject
+func updateClusters(hsoKey string, cp Options, hso *httpaddonv1alpha1.HTTPScaledObject, clusters []*clusterv3.Cluster) ([]*clusterv3.Cluster, error) {
+	if !hso.DeletionTimestamp.IsZero() {
+		for i, cluster := range clusters {
+			if cluster.Name == hsoKey {
+				clusters = append(clusters[:i], clusters[i+1:]...)
+				break
+			}
+		}
+		return clusters, nil
+	}
+	for _, cluster := range clusters {
+		if cluster.Name == hsoKey {
+			return clusters, nil
+		}
+	}
+
+	address := fmt.Sprintf("%v.%v.svc.%v", hso.Spec.ScaleTargetRef.Service, hso.Namespace, cp.ClusterDomain)
+	lbEndpoint := getLoadBalancerEndpoint(address, hso.Spec.ScaleTargetRef.Port)
+	cluster := &clusterv3.Cluster{
+		Name: hsoKey,
+		ConnectTimeout: &duration.Duration{
+			Seconds: int64(math.Ceil(cp.ConnectionTimeout.Seconds())),
+		},
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_STRICT_DNS,
+		},
+		LbPolicy: clusterv3.Cluster_ROUND_ROBIN,
+		LoadAssignment: &endpointv3.ClusterLoadAssignment{
+			ClusterName: hsoKey,
+			Endpoints: []*endpointv3.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*endpointv3.LbEndpoint{lbEndpoint},
+				},
+			},
+		},
+	}
+	clusters = append(clusters, cluster)
+	sort.Slice(clusters, func(i, j int) bool {
+		return clusters[i].Name < clusters[j].Name
+	})
+	return clusters, nil
+}
+
+// setClusters sets the clusters in the resources map
+func setClusters(resources map[resource.Type][]types.Resource, clusters []*clusterv3.Cluster) {
+	clusterResources := make([]types.Resource, len(clusters))
+	for i, c := range clusters {
+		clusterResources[i] = c
+	}
+	resources[resource.ClusterType] = clusterResources
+}
+
+// addResources adds the envoy resources to the snapshot cache based on the input values from the HTTPScaledObjects
+// * listeners - only one shared for all of the HTTPScaledObjects
+// * listeners.filter_chains - also only one shared for all of the HTTPScaledObjects
+// * listeners.filter_chains.filters - also only one shared for all of the HTTPScaledObjects
+//
+// * listeners.filter_chains.filters.http_connection_manager.route_config.virtual_hosts - one for each HTTPScaledObject
+// * listeners.filter_chains.filters.http_connection_manager.route_config.virtual_hosts.routes - one for each HTTPScaledObject.Spec.PathPrefix
+//
+// * clusters - one for each HTTPScaledObject
+func addResources(resources map[resource.Type][]types.Resource, cp Options, hsos ...httpaddonv1alpha1.HTTPScaledObject) error {
+	for _, hso := range hsos {
+		hsoKey := fmt.Sprintf("%s/%s", hso.Namespace, hso.Name)
+		listener, err := getListener(resources)
+		if err != nil {
+			return fmt.Errorf("failed to get listener: %w", err)
+		}
+		if err := updateListener(hsoKey, &hso, listener); err != nil {
+			return fmt.Errorf("failed to update listener: %w", err)
+		}
+
+		clusters := getClusters(resources, cp)
+		updatedClusters, err := updateClusters(hsoKey, cp, &hso, clusters)
+		if err != nil {
+			return fmt.Errorf("failed to update cluster: %w", err)
+		}
+		setClusters(resources, updatedClusters)
+	}
+	return nil
+}

--- a/interceptor/envoycp/server.go
+++ b/interceptor/envoycp/server.go
@@ -1,0 +1,221 @@
+package envoycp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/exp/maps"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	workqueue "k8s.io/client-go/util/workqueue"
+
+	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
+	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
+	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
+	runtimeservice "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
+	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+
+	envoysink "github.com/kedacore/http-add-on/interceptor/envoysink"
+	httpaddonv1alpha1 "github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
+	clientset "github.com/kedacore/http-add-on/operator/generated/clientset/versioned"
+)
+
+const (
+	// NodeID is the node ID for the Envoy snapshot belonging to the kedify-proxy
+	NodeID = "kedify-proxy"
+)
+
+// Options are the options for the Envoy control plane server
+type Options struct {
+	ClusterDomain     string
+	ControlPlaneHost  string
+	ControlPlanePort  uint32
+	ConnectionTimeout time.Duration
+}
+
+// Server is the interface for the Envoy control plane server
+type Server interface {
+	Run(ctx context.Context) error
+	HandleHSO(ctx context.Context, hso *httpaddonv1alpha1.HTTPScaledObject)
+}
+
+// server is the implementation of the Server interface
+type server struct {
+	logger    logr.Logger
+	cache     cachev3.SnapshotCache
+	queue     workqueue.RateLimitingInterface
+	k8sClient clientset.Interface
+	cp        Options
+}
+
+// NewServer creates a new instance of the Server interface
+func NewServer(l logr.Logger, k8sClient clientset.Interface, cp Options) Server {
+	logAdapter := log.LoggerFuncs{
+		WarnFunc:  func(f string, args ...any) { l.Info(fmt.Sprintf("[WARN]  "+f, args...)) },
+		ErrorFunc: func(f string, args ...any) { l.Info(fmt.Sprintf("[ERROR] "+f, args...)) },
+	}
+	if l.V(1).Enabled() {
+		logAdapter.InfoFunc = func(f string, args ...any) { l.Info(fmt.Sprintf("[INFO]  "+f, args...)) }
+	}
+	if l.V(2).Enabled() {
+		logAdapter.DebugFunc = func(f string, args ...any) { l.Info(fmt.Sprintf("[DEBUG] "+f, args...)) }
+	}
+	return &server{
+		cp:        cp,
+		cache:     cachev3.NewSnapshotCache(false, cachev3.IDHash{}, logAdapter),
+		logger:    l,
+		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "envoy-control-plane"),
+		k8sClient: k8sClient,
+	}
+}
+
+// loggingUnaryInterceptor is optional gRPC endpoint log for single requests
+func (s *server) loggingUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	s.logger.V(4).Info("received unary request", "method", info.FullMethod)
+	return handler(ctx, req)
+}
+
+// loggingStreamInterceptor is optional gRPC endpoint log for streaming requests
+func (s *server) loggingStreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	s.logger.V(4).Info("received stream request", "method", info.FullMethod)
+	return handler(srv, ss)
+}
+
+// Run starts the Envoy control plane server
+func (s *server) Run(ctx context.Context) error {
+	s.runWorkqueue(ctx)
+	srv3 := serverv3.NewServer(ctx, s.cache, nil)
+	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(s.loggingUnaryInterceptor),
+		grpc.StreamInterceptor(s.loggingStreamInterceptor),
+	)
+	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", s.cp.ControlPlanePort))
+	if err != nil {
+		return err
+	}
+
+	reflection.Register(grpcServer)
+	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, srv3)
+	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, srv3)
+	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, srv3)
+	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, srv3)
+	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, srv3)
+	secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, srv3)
+	runtimeservice.RegisterRuntimeDiscoveryServiceServer(grpcServer, srv3)
+
+	return grpcServer.Serve(lis)
+}
+
+// HandleHSO adds the HTTPScaledObject to the workqueue for further processing and forming envoy snapshot cache
+func (s *server) HandleHSO(ctx context.Context, hso *httpaddonv1alpha1.HTTPScaledObject) {
+	s.queue.Add(hso)
+}
+
+// handleHSO updates the envoy fleet configuration in snapshot cache and sets the metric aggregation
+// key in HTTPScaledObject annotation
+func (s *server) handleHSO(ctx context.Context, hso *httpaddonv1alpha1.HTTPScaledObject) error {
+	s.logger.V(4).Info("handling HSO", "namespace", hso.Namespace, "name", hso.Name)
+	hso.Annotations[envoysink.EnvoyClusterNameAnnotation] = fmt.Sprintf("%s/%s", hso.Namespace, hso.Name)
+	cacheSnap, err := s.cache.GetSnapshot(NodeID)
+	if err != nil {
+		if err := s.initNewSnapshot(ctx); err != nil {
+			return fmt.Errorf("failed to init envoy snapshot: %w", err)
+		}
+		return nil
+	}
+	snap, ok := cacheSnap.(*cachev3.Snapshot)
+	if !ok {
+		return fmt.Errorf("failed to cast snapshot to cachev3.Snapshot")
+	}
+	if err := s.updateSnapshot(snap, hso); err != nil {
+		return fmt.Errorf("failed to update snapshot: %w", err)
+	}
+	return nil
+}
+
+// runWorkqueue runs the workqueue for handling HTTPScaledObjects
+func (s *server) runWorkqueue(ctx context.Context) {
+	go func() {
+		for {
+			obj, shutdown := s.queue.Get()
+			if shutdown {
+				return
+			}
+			defer s.queue.Done(obj)
+			hso, ok := obj.(*httpaddonv1alpha1.HTTPScaledObject)
+			if !ok {
+				s.logger.Info("invalid object type in workqueue", "type", fmt.Sprintf("%T", obj))
+				s.queue.Forget(obj)
+				continue
+			}
+			if err := s.handleHSO(ctx, hso); err != nil {
+				s.logger.Error(err, "failed to handle HTTPScaledObject for envoy cache update", "namespace", hso.Namespace, "name", hso.Name)
+				s.queue.AddRateLimited(obj)
+			} else {
+				s.queue.Forget(obj)
+			}
+		}
+	}()
+}
+
+// updateSnapshot updates the snapshot with the new HTTPScaledObject
+func (s *server) updateSnapshot(snap *cachev3.Snapshot, hso *httpaddonv1alpha1.HTTPScaledObject) error {
+	resources := make(map[resource.Type][]types.Resource)
+	resources[resource.ListenerType] = maps.Values(snap.GetResources(resource.ListenerType))
+	resources[resource.ClusterType] = maps.Values(snap.GetResources(resource.ClusterType))
+
+	if err := addResources(resources, s.cp, *hso); err != nil {
+		return fmt.Errorf("failed to add resources: %w", err)
+	}
+	version := getResourcesVersion(resources)
+	newSnap, err := cachev3.NewSnapshot(version, resources)
+	if err != nil {
+		return fmt.Errorf("failed to create new snapshot with updated resources: %w", err)
+	}
+	if snapVersion(snap) == snapVersion(newSnap) {
+		s.logger.V(1).Info("snapshot version is the same, skipping update", "version", version, "nodeID", NodeID)
+		return nil
+	}
+
+	s.logger.V(1).Info("setting new snapshot", "version", version, "nodeID", NodeID)
+	if err := s.cache.SetSnapshot(context.Background(), NodeID, newSnap); err != nil {
+		return fmt.Errorf("failed to set snapshot: %w", err)
+	}
+	return nil
+}
+
+// initNewSnapshot initializes a new snapshot when there is no existing snapshot in the cache
+func (s *server) initNewSnapshot(ctx context.Context) error {
+	hsoList, err := s.k8sClient.HttpV1alpha1().HTTPScaledObjects("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list HTTPScaledObjects: %w", err)
+	}
+	resources := make(map[resource.Type][]types.Resource)
+	if err := addResources(resources, s.cp, hsoList.Items...); err != nil {
+		return fmt.Errorf("failed to add resources: %w", err)
+	}
+
+	version := getResourcesVersion(resources)
+	snap, err := cachev3.NewSnapshot(version, resources)
+	if err != nil {
+		return fmt.Errorf("failed to create new snapshot: %w", err)
+	}
+
+	s.logger.V(1).Info("setting new snapshot", "version", version, "nodeID", NodeID)
+	if err := s.cache.SetSnapshot(ctx, NodeID, snap); err != nil {
+		return fmt.Errorf("failed to set snapshot: %w", err)
+	}
+	return nil
+}

--- a/interceptor/envoysink/metrics_server.go
+++ b/interceptor/envoysink/metrics_server.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	// envoyClusterNameAnnotation is the annotation key for the envoy cluster name.
-	envoyClusterNameAnnotation = "http.kedify.io/envoy-cluster-name"
+	// EnvoyClusterNameAnnotation is the annotation key for the envoy cluster name.
+	EnvoyClusterNameAnnotation = "http.kedify.io/envoy-cluster-name"
 	externalProxyMetricKey     = "http.kedify.io/external-proxy-metric-key"
 
 	// envoy metrics representing RPS and pending requests.
@@ -227,7 +227,7 @@ func getClusterNameFromAnnotations(annotations map[string]string) string {
 	if annotations[externalProxyMetricKey] != "" {
 		return annotations[externalProxyMetricKey]
 	}
-	return annotations[envoyClusterNameAnnotation]
+	return annotations[EnvoyClusterNameAnnotation]
 }
 
 // addCluserNameToMetrics adds the cluster name to the metrics.


### PR DESCRIPTION
When investigating `interceptor` performance degradation, resource requirements and overhead for the traffic, we decided to explore and compare it to established reverse proxy software.

With a simple benchmark sending 40k req/min from 3000 clients, `interceptor` required more resources
* 1 CPU core
* 450Mi of memory
* Average latency: 3.8093 secs
 
For the same benchmark execution, the envoy proxy required fewer resources and had significantly lower delay overhead
* 0.450 CPU core
* 153Mi of memory
* Average latency: 0.3040 secs

Since https://github.com/kedify/http-add-on/pull/3, `interceptor` is able to accept and ingest envoy metrics from external envoy deployments. This PR enhances the envoy integration with the implementation of an xDS control plane for automatic route configuration. This can be used to fully offload the traffic from the interceptor to envoy for performance gain and reduced resource consumption.

Each envoy that desires to be configured by the `interceptor` should include the following bootstrap config
```yaml
stats_sinks:
￼  name: keda_http_add_on
￼  typed_config:
￼    "@type": type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
￼    transport_api_version: V3
￼    report_counters_as_deltas: true
￼    emit_tags_as_labels: true
￼    grpc_service:
￼      google_grpc: keda-add-ons-http-interceptor-kedify-proxy-metric-sink.keda.svc.cluster.local:9901
￼        stat_prefix: kedify_
￼node:
￼  id: kedify-proxy
￼  cluster: xds_cluster
￼admin:
￼  address:
￼    socket_address:
￼      address: 0.0.0.0
￼      port_value: 9901
￼dynamic_resources:
￼  lds_config:
￼    api_config_source:
￼      api_type: GRPC
￼      transport_api_version: V3
￼      grpc_services:
￼      - envoy_grpc:
￼          cluster_name: xds_cluster
￼  cds_config:
￼    api_config_source:
￼      api_type: GRPC
￼      transport_api_version: V3
￼      grpc_services:
￼      - envoy_grpc:
￼          cluster_name: xds_cluster
￼static_resources:
￼  clusters:
￼  - name: xds_cluster
￼    connect_timeout: 2s
￼    type: STRICT_DNS
￼    lb_policy: ROUND_ROBIN
￼    http2_protocol_options: {}
￼    upstream_http_protocol_options: {}
￼    load_assignment:
￼      cluster_name: xds_cluster
￼      endpoints:
￼      - lb_endpoints:
￼        - endpoint:
￼            address:
￼              socket_address:
￼                address: keda-add-ons-http-interceptor-kedify-proxy-metric-sink.keda.svc.cluster.local
￼                port_value: 5678
```